### PR TITLE
Make app/channel listener names const char * to save RAM

### DIFF
--- a/sh2.c
+++ b/sh2.c
@@ -338,65 +338,78 @@ typedef struct sh2_s {
 			sh2_SensorConfig_t *pConfig;
 			sh2_SensorId_t sensorId;
 		} getSensorConfig;
-		struct {
-			const sh2_SensorConfig_t *pConfig;
-			sh2_SensorId_t sensorId;
-		} setSensorConfig;
-		struct {
-			uint16_t frsType;
-			uint32_t *pData;
-			uint16_t *pWords;
-			uint16_t nextOffset;
-			sh2_SensorMetadata_t *pMetadata;
-		} getFrs;
-		struct {
-			uint16_t frsType;
-			uint32_t *pData;
-			uint16_t words;
-			uint16_t offset;
-		} setFrs;
-		struct {
-			uint8_t seq;
-			uint8_t severity;
-			sh2_ErrorRecord_t *pErrors;
-			uint16_t *pNumErrors;
-			uint16_t errsRead;
-		} getErrors;
-		struct {
-			uint8_t seq;
-			sh2_SensorId_t sensorId;
-			sh2_Counts_t *pCounts;
-		} getCounts;
-		struct {
-			uint8_t seq;
-		} reinit;
-		struct {
-			uint8_t seq;
-		} saveDcdNow;
-		struct {
-			uint8_t sensors;
-			uint8_t seq;
-		} calConfig;
-		struct {
-			uint8_t *pSensors;
-			uint8_t seq;
-		} getCalConfig;
-		struct {
-			sh2_SensorId_t sensorId;
-		} forceFlush;
-        struct {
-            uint8_t seq;
-            sh2_OscType_t *pOscType;
-        } getOscType;
-        struct {
-            uint32_t interval_us;
-            uint8_t seq;
-        } startCal;
-        struct {
-            sh2_CalStatus_t status;
-            uint8_t seq;
-        } finishCal;
-    } opData;
+                struct
+                {
+                    const sh2_SensorConfig_t *pConfig;
+                    sh2_SensorId_t sensorId;
+                } setSensorConfig;
+                struct
+                {
+                    uint16_t frsType;
+                    uint32_t *pData;
+                    uint16_t *pWords;
+                    uint16_t nextOffset;
+                    sh2_SensorMetadata_t *pMetadata;
+                } getFrs;
+                struct
+                {
+                    uint16_t frsType;
+                    uint32_t *pData;
+                    uint16_t words;
+                    uint16_t offset;
+                } setFrs;
+                struct
+                {
+                    uint8_t seq;
+                    uint8_t severity;
+                    sh2_ErrorRecord_t *pErrors;
+                    uint16_t *pNumErrors;
+                    uint16_t errsRead;
+                } getErrors;
+                struct
+                {
+                    uint8_t seq;
+                    sh2_SensorId_t sensorId;
+                    sh2_Counts_t *pCounts;
+                } getCounts;
+                struct
+                {
+                    uint8_t seq;
+                } reinit;
+                struct
+                {
+                    uint8_t seq;
+                } saveDcdNow;
+                struct
+                {
+                    uint8_t sensors;
+                    uint8_t seq;
+                } calConfig;
+                struct
+                {
+                    uint8_t *pSensors;
+                    uint8_t seq;
+                } getCalConfig;
+                struct
+                {
+                    sh2_SensorId_t sensorId;
+                } forceFlush;
+                struct
+                {
+                    uint8_t seq;
+                    sh2_OscType_t *pOscType;
+                } getOscType;
+                struct
+                {
+                    uint32_t interval_us;
+                    uint8_t seq;
+                } startCal;
+                struct
+                {
+                    sh2_CalStatus_t status;
+                    uint8_t seq;
+                } finishCal;
+        } opData;
 
 } sh2_t;
 
@@ -405,18 +418,23 @@ static int16_t toQ14(double x);
 static void setupCmdParams(uint8_t cmd, uint8_t p[9]);
 static void setupCmd0(uint8_t cmd);
 static void setupCmd1(uint8_t cmd, uint8_t p0);
-    
-static void executableAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val);
-static void executableDeviceHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
 
-static void sensorhubAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val);
-static void sensorhubControlHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
-static void sensorhubInputNormalHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
-static void sensorhubInputWakeHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
-static void sensorhubInputGyroRvHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
+static void executableAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, const uint8_t *val);
+static void
+executableDeviceHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+
+static void sensorhubAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, const uint8_t *val);
+static void
+sensorhubControlHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+static void
+sensorhubInputNormalHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+static void
+sensorhubInputWakeHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+static void
+sensorhubInputGyroRvHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
 
 static uint8_t getReportLen(uint8_t reportId);
-    
+
 // SH-2 transaction phases
 static int opStart(const sh2_Op_t *pOp);
 static void opTxDone(void);
@@ -919,29 +937,31 @@ static void setupCmd1(uint8_t cmd, uint8_t p0)
     setupCmdParams(cmd, p);
 }
 
-static void sensorhubAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val)
+static void sensorhubAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, const uint8_t *val)
 {
-
-    switch (tag) {
+    switch (tag)
+    {
         case TAG_SH2_VERSION:
             strcpy(sh2.version, (const char *)val);
             break;
 
         case TAG_SH2_REPORT_LENGTHS:
         {
-            uint8_t reports = len/2;
-            if (reports > SH2_MAX_REPORT_IDS) {
+            uint8_t reports = len / 2;
+            if (reports > SH2_MAX_REPORT_IDS)
+            {
                 // Hub gave us more report lengths than we can store!
                 reports = SH2_MAX_REPORT_IDS;
             }
-        
-            for (int n = 0; n < reports; n++) {
-                sh2.report[n].id = val[n*2];
-                sh2.report[n].len = val[n*2 + 1];
+
+            for (int n = 0; n < reports; n++)
+            {
+                sh2.report[n].id = val[n * 2];
+                sh2.report[n].len = val[n * 2 + 1];
             }
             break;
         }
-    
+
         case 0:
         {
             // 0 tag indicates end of advertisements for this app
@@ -957,42 +977,51 @@ static void sensorhubAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t 
     }
 }
 
-static void sensorhubControlHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void
+sensorhubControlHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
     uint16_t cursor = 0;
     uint32_t count = 0;
-    CommandResp_t * pResp = 0;
+    CommandResp_t *pResp = 0;
     sh2_AsyncEvent_t event;
-    
-    if (len == 0) {
+
+    if (len == 0)
+    {
         sh2.emptyPayloads++;
         return;
     }
 
-    while (cursor < len) {
+    while (cursor < len)
+    {
         // Get next report id
         count++;
         uint8_t reportId = payload[cursor];
 
         // Determine report length
         uint8_t reportLen = 0;
-        for (int n = 0; n < SH2_MAX_REPORT_IDS; n++) {
-            if (sh2.report[n].id == reportId) {
+        for (int n = 0; n < SH2_MAX_REPORT_IDS; n++)
+        {
+            if (sh2.report[n].id == reportId)
+            {
                 reportLen = sh2.report[n].len;
                 break;
             }
         }
-        if (reportLen == 0) {
+        if (reportLen == 0)
+        {
             // An unrecognized report id
             sh2.unknownReportIds++;
             return;
         }
-        else {
+        else
+        {
             // Check for unsolicited initialize response or FRS change response
-            if (reportId == SENSORHUB_COMMAND_RESP) {
-                pResp = (CommandResp_t *)(payload+cursor);
+            if (reportId == SENSORHUB_COMMAND_RESP)
+            {
+                pResp = (CommandResp_t *)(payload + cursor);
                 if ((pResp->command == (SH2_CMD_INITIALIZE | SH2_INIT_UNSOLICITED)) &&
-                    (pResp->r[1] == SH2_INIT_SYSTEM)) {
+                    (pResp->r[1] == SH2_INIT_SYSTEM))
+                {
                     // This is an unsolicited INIT message.
                     // Is it time to call reset callback?
                     sh2.gotInitResp = true;
@@ -1002,7 +1031,8 @@ static void sensorhubControlHdlr(void *cookie, uint8_t *payload, uint16_t len, u
                     // This is an unsolicited FRS change message
                     event.eventId = SH2_FRS_CHANGE;
                     event.frsType = pResp->r[1] + (pResp->r[2] << 8);
-                    if (sh2.eventCallback) {
+                    if (sh2.eventCallback)
+                    {
                         sh2.eventCallback(sh2.eventCallbackCookie, &event);
                     }
 				}
@@ -1015,7 +1045,7 @@ static void sensorhubControlHdlr(void *cookie, uint8_t *payload, uint16_t len, u
     }
 }
 
-static void sensorhubInputHdlr(uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void sensorhubInputHdlr(const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
     sh2_SensorEvent_t event;
     uint16_t cursor = 0;
@@ -1024,13 +1054,15 @@ static void sensorhubInputHdlr(uint8_t *payload, uint16_t len, uint32_t timestam
 
     referenceDelta = 0;
 
-    while (cursor < len) {
+    while (cursor < len)
+    {
         // Get next report id
         uint8_t reportId = payload[cursor];
 
         // Determine report length
         uint8_t reportLen = getReportLen(reportId);
-        if (reportLen == 0) {
+        if (reportLen == 0)
+        {
             // An unrecognized report id
             sh2.unknownReportIds++;
             return;
@@ -1052,7 +1084,7 @@ static void sensorhubInputHdlr(uint8_t *payload, uint16_t len, uint32_t timestam
                 opRx(payload+cursor, reportLen);
             }
             else {
-                uint8_t *pReport = payload+cursor;
+                const uint8_t *pReport = payload + cursor;
                 uint16_t delay = ((pReport[2] & 0xFC) << 6) + pReport[3];
                 event.timestamp_uS = touSTimestamp(timestamp, referenceDelta, delay);
                 event.reportId = reportId;
@@ -1068,19 +1100,22 @@ static void sensorhubInputHdlr(uint8_t *payload, uint16_t len, uint32_t timestam
     }
 }
 
-static void sensorhubInputNormalHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void
+sensorhubInputNormalHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
-    
+
     sensorhubInputHdlr(payload, len, timestamp);
 }
 
-static void sensorhubInputWakeHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void
+sensorhubInputWakeHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
-    
+
     sensorhubInputHdlr(payload, len, timestamp);
 }
 
-static void sensorhubInputGyroRvHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void
+sensorhubInputGyroRvHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
 
     sh2_SensorEvent_t event;
@@ -1089,14 +1124,16 @@ static void sensorhubInputGyroRvHdlr(void *cookie, uint8_t *payload, uint16_t le
     uint8_t reportId = SH2_GYRO_INTEGRATED_RV;
     uint8_t reportLen = getReportLen(reportId);
 
-    while (cursor < len) {
+    while (cursor < len)
+    {
         event.timestamp_uS = timestamp;
         event.reportId = reportId;
-        memcpy(event.report, payload+cursor, reportLen);
+        memcpy(event.report, payload + cursor, reportLen);
         /// event.pReport = payload+cursor;
         event.len = reportLen;
 
-        if (sh2.sensorCallback != 0) {
+        if (sh2.sensorCallback != 0)
+        {
             sh2.sensorCallback(sh2.sensorCallbackCookie, &event);
         }
 
@@ -2050,9 +2087,10 @@ static void finishCalRx(const uint8_t *payload, uint16_t len)
     return;
 }
 
-static void executableAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val)
+static void executableAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, const uint8_t *val)
 {
-    switch (tag) {
+    switch (tag)
+    {
         default:
             // Ignore unknown tags
             // (And there are no known tags for this app.)
@@ -2060,21 +2098,25 @@ static void executableAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t
     }
 }
 
-static void executableDeviceHdlr(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void
+executableDeviceHdlr(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
     sh2_AsyncEvent_t event;
 
     // Discard if length is bad
-    if (len != 1) {
+    if (len != 1)
+    {
         sh2.execBadPayload++;
         return;
     }
-    
-    switch (payload[0]) {
+
+    switch (payload[0])
+    {
         case EXECUTABLE_DEVICE_RESP_RESET_COMPLETE:
             // Notify client that reset is complete.
             event.eventId = SH2_RESET;
-            if (sh2.eventCallback) {
+            if (sh2.eventCallback)
+            {
                 sh2.eventCallback(sh2.eventCallbackCookie, &event);
             }
             break;

--- a/sh2.c
+++ b/sh2.c
@@ -483,7 +483,7 @@ const sh2_Op_t setSensorConfigOp = {
 // get FRS Operation
 static int getFrsStart(void);
 static void getFrsRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t getFrsOp = {
+static const sh2_Op_t getFrsOp = {
     .start = getFrsStart,
     .rx = getFrsRx,
 };
@@ -491,7 +491,7 @@ const sh2_Op_t getFrsOp = {
 // set FRS Operation
 static int setFrsStart(void);
 static void setFrsRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t setFrsOp = {
+static const sh2_Op_t setFrsOp = {
     .start = setFrsStart,
     .rx = setFrsRx,
 };
@@ -499,7 +499,7 @@ const sh2_Op_t setFrsOp = {
 // get errors operation
 static int getErrorsStart(void);
 static void getErrorsRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t getErrorsOp = {
+static const sh2_Op_t getErrorsOp = {
     .start = getErrorsStart,
     .rx = getErrorsRx,
 };
@@ -507,7 +507,7 @@ const sh2_Op_t getErrorsOp = {
 // get counts operation
 static int getCountsStart(void);
 static void getCountsRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t getCountsOp = {
+static const sh2_Op_t getCountsOp = {
     .start = getCountsStart,
     .rx = getCountsRx,
 };
@@ -515,7 +515,7 @@ const sh2_Op_t getCountsOp = {
 // reinitialize operation
 static int reinitStart(void);
 static void reinitRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t reinitOp = {
+static const sh2_Op_t reinitOp = {
     .start = reinitStart,
     .rx = reinitRx,
 };
@@ -523,7 +523,7 @@ const sh2_Op_t reinitOp = {
 // save dcd now operation
 static int saveDcdNowStart(void);
 static void saveDcdNowRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t saveDcdNowOp = {
+static const sh2_Op_t saveDcdNowOp = {
     .start = saveDcdNowStart,
     .rx = saveDcdNowRx,
 };
@@ -531,7 +531,7 @@ const sh2_Op_t saveDcdNowOp = {
 // cal config operation
 static int calConfigStart(void);
 static void calConfigRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t calConfigOp = {
+static const sh2_Op_t calConfigOp = {
     .start = calConfigStart,
     .rx = calConfigRx,
 };
@@ -539,7 +539,7 @@ const sh2_Op_t calConfigOp = {
 // get cal config operation
 static int getCalConfigStart(void);
 static void getCalConfigRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t getCalConfigOp = {
+static const sh2_Op_t getCalConfigOp = {
     .start = getCalConfigStart,
     .rx = getCalConfigRx,
 };
@@ -547,7 +547,7 @@ const sh2_Op_t getCalConfigOp = {
 // force flush operation
 static int forceFlushStart(void);
 static void forceFlushRx(const uint8_t *payload, uint16_t len);
-const sh2_Op_t forceFlushOp = {
+static const sh2_Op_t forceFlushOp = {
     .start = forceFlushStart,
     .rx = forceFlushRx,
 };

--- a/shtp.c
+++ b/shtp.c
@@ -30,6 +30,8 @@
 
 #define SH2_MAX_CHANS (8)
 #define SH2_MAX_APPS (5)
+#define SH2_MAX_CHANNEL_LISTENERS 6
+#define SH2_MAX_APP_LISTENERS     3
 #define SHTP_APP_NAME_LEN (32)
 #define SHTP_CHAN_NAME_LEN (32)
 
@@ -132,12 +134,12 @@ typedef struct shtp_s {
     shtp_App_t app[SH2_MAX_APPS];
     uint8_t    nextApp;
     
-    shtp_AppListener_t appListener[SH2_MAX_APPS];
+    shtp_AppListener_t appListener[SH2_MAX_APP_LISTENERS];
     uint8_t            nextAppListener;
 
     // Channels and their listeners
     shtp_Channel_t      chan[SH2_MAX_CHANS];
-    shtp_ChanListener_t chanListener[SH2_MAX_CHANS];
+    shtp_ChanListener_t chanListener[SH2_MAX_CHANNEL_LISTENERS];
     uint8_t nextChanListener;
 
 } shtp_t;
@@ -196,7 +198,7 @@ int shtp_init(void)
     shtp.advertPhase = ADVERT_NEEDED;
 
     // Init App Listeners
-    for (unsigned int n = 0; n < SH2_MAX_APPS; n++)
+    for (unsigned int n = 0; n < SH2_MAX_APP_LISTENERS; n++)
     {
 #ifdef CONFIG_SHTP_CONST_NAMES
         shtp.appListener[n].appName = "";
@@ -220,7 +222,7 @@ int shtp_init(void)
     }
 
     // Init registered channel listeners array
-    for (unsigned int n = 0; n < SH2_MAX_CHANS; n++)
+    for (unsigned int n = 0; n < SH2_MAX_CHANNEL_LISTENERS; n++)
     {
 #ifdef CONFIG_SHTP_CONST_NAMES
         shtp.chanListener[n].appName = "";
@@ -450,7 +452,7 @@ static void updateCallbacks(void)
         }
         else {
             // Look for a listener registered with this app name, channel name
-            for (int listenerNo = 0; listenerNo < SH2_MAX_CHANS; listenerNo++) {
+            for (int listenerNo = 0; listenerNo < SH2_MAX_CHANNEL_LISTENERS; listenerNo++) {
                 if ((shtp.chanListener[listenerNo].callback != 0) &&
                     (strcmp(appName, shtp.chanListener[listenerNo].appName) == 0) &&
                     (strcmp(chanName, shtp.chanListener[listenerNo].chanName) == 0)) {
@@ -568,7 +570,7 @@ static void callAdvertHandler(uint32_t guid, uint8_t tag, uint8_t len, const uin
     }
     
     // Find listener for this app
-    for (int n = 0; n < SH2_MAX_APPS; n++)
+    for (int n = 0; n < SH2_MAX_APP_LISTENERS; n++)
     {
         if (strcmp(shtp.appListener[n].appName, appName) == 0) {
             // Found matching App entry
@@ -686,7 +688,7 @@ static void addAdvertListener(const char *appName,
     shtp_AppListener_t *pAppListener = 0;
 
     // Bail out if no space for more apps
-    if (shtp.nextAppListener >= SH2_MAX_APPS)
+    if (shtp.nextAppListener >= SH2_MAX_APP_LISTENERS)
         return;
 
     // Register this app
@@ -708,7 +710,7 @@ static int addChanListener(const char * appName, const char * chanName,
     shtp_ChanListener_t *pListener = 0;
 
     // Bail out if there are too many listeners registered
-    if (shtp.nextChanListener >= SH2_MAX_CHANS)
+    if (shtp.nextChanListener >= SH2_MAX_CHANNEL_LISTENERS)
         return SH2_ERR;
 
     // Register channel listener

--- a/shtp.c
+++ b/shtp.c
@@ -153,7 +153,7 @@ static void addAdvertListener(const char *appName, shtp_AdvertCallback_t *callba
 static int
 addChanListener(const char *appName, const char *chanName, shtp_Callback_t *callback, void *cookie);
 static int toChanNo(const char *appName, const char *chanName);
-static int txProcess(uint8_t chan, uint8_t *pData, uint32_t len);
+static int txProcess(uint8_t chan, const uint8_t *pData, uint32_t len);
 
 // ------------------------------------------------------------------------
 // Private, static data
@@ -766,7 +766,7 @@ static inline uint16_t min(uint16_t a, uint16_t b)
 }
 
 // Send a cargo as a sequence of transports
-static int txProcess(uint8_t chan, uint8_t* pData, uint32_t len)
+static int txProcess(uint8_t chan, const uint8_t *pData, uint32_t len)
 {
     int status = SH2_OK;
     

--- a/shtp.c
+++ b/shtp.c
@@ -137,24 +137,23 @@ typedef struct shtp_s {
     // Channels and their listeners
     shtp_Channel_t      chan[SH2_MAX_CHANS];
     shtp_ChanListener_t chanListener[SH2_MAX_CHANS];
-    uint8_t             nextChanListener;
+    uint8_t nextChanListener;
 
 } shtp_t;
 
 // ------------------------------------------------------------------------
 // Forward definitions
 
-static void shtp_onRx(void* cookie, uint8_t* pdata, uint32_t len, uint32_t t_us);
+static void shtp_onRx(void *cookie, uint8_t *pdata, uint32_t len, uint32_t t_us);
 static void addApp(uint32_t guid, const char *appName);
-static void addChannel(uint8_t chanNo, uint32_t guid, const char * chanName, bool wake);
-static void shtpAdvertHdlr(void *shtp, uint8_t tag, uint8_t len, uint8_t *val);
-static void shtpCmdListener(void *shtp, uint8_t *payload, uint16_t len, uint32_t timestamp);
-static void addAdvertListener(const char *appName,
-                              shtp_AdvertCallback_t *callback, void * cookie);
-static int addChanListener(const char * appName, const char * chanName,
-                           shtp_Callback_t *callback, void *cookie);
-static int toChanNo(const char * appName, const char *chanName);
-static int txProcess(uint8_t chan, uint8_t* pData, uint32_t len);
+static void addChannel(uint8_t chanNo, uint32_t guid, const char *chanName, bool wake);
+static void shtpAdvertHdlr(void *shtp, uint8_t tag, uint8_t len, const uint8_t *val);
+static void shtpCmdListener(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+static void addAdvertListener(const char *appName, shtp_AdvertCallback_t *callback, void *cookie);
+static int
+addChanListener(const char *appName, const char *chanName, shtp_Callback_t *callback, void *cookie);
+static int toChanNo(const char *appName, const char *chanName);
+static int txProcess(uint8_t chan, uint8_t *pData, uint32_t len);
 
 // ------------------------------------------------------------------------
 // Private, static data
@@ -510,16 +509,17 @@ static void addChannel(uint8_t chanNo, uint32_t guid, const char * chanName, boo
     updateCallbacks();
 }
 
-
 // Callback for SHTP app-specific advertisement tags
-static void shtpAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val)
+static void shtpAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, const uint8_t *val)
 {
     uint16_t x;
 
-    switch (tag) {
+    switch (tag)
+    {
         case TAG_MAX_CARGO_PLUS_HEADER_WRITE:
             x = readu16(val) - SHTP_HDR_LEN;
-            if (x < SHTP_MAX_PAYLOAD_OUT) {
+            if (x < SHTP_MAX_PAYLOAD_OUT)
+            {
                 shtp.outMaxPayload = x;
             }
             break;
@@ -551,8 +551,7 @@ static void shtpAdvertHdlr(void *cookie, uint8_t tag, uint8_t len, uint8_t *val)
     }
 }
 
-static void callAdvertHandler(uint32_t guid,
-                              uint8_t tag, uint8_t len, uint8_t *val)
+static void callAdvertHandler(uint32_t guid, uint8_t tag, uint8_t len, const uint8_t *val)
 {
     // Find app name for this GUID
     const char * appName = 0;
@@ -580,11 +579,11 @@ static void callAdvertHandler(uint32_t guid,
     }
 }
 
-static void processAdvertisement(uint8_t *payload, uint16_t payloadLen)
+static void processAdvertisement(const uint8_t *payload, uint16_t payloadLen)
 {
     uint8_t tag;
     uint8_t len;
-    uint8_t *val;
+    const uint8_t *val;
     uint16_t cursor = 1;
     uint32_t guid = 0;
     char appName[SHTP_APP_NAME_LEN];
@@ -661,13 +660,15 @@ static void processAdvertisement(uint8_t *payload, uint16_t payloadLen)
 }
 
 // Callback for SHTP command channel
-static void shtpCmdListener(void *cookie, uint8_t *payload, uint16_t len, uint32_t timestamp)
+static void shtpCmdListener(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp)
 {
-    if ((payload == 0) || (len == 0)) return;
-    
+    if ((payload == 0) || (len == 0))
+        return;
+
     uint8_t response = payload[0];
 
-    switch (response) {
+    switch (response)
+    {
         case RESP_ADVERTISE:
             processAdvertisement(payload, len);
             break;

--- a/shtp.h
+++ b/shtp.h
@@ -33,29 +33,28 @@ extern "C" {
 #define TAG_NULL 0
 #define TAG_GUID 1
 #define TAG_MAX_CARGO_PLUS_HEADER_WRITE 2
-#define TAG_MAX_CARGO_PLUS_HEADER_READ 3
-#define TAG_MAX_TRANSFER_WRITE 4
-#define TAG_MAX_TRANSFER_READ 5
-#define TAG_NORMAL_CHANNEL 6
-#define TAG_WAKE_CHANNEL 7
-#define TAG_APP_NAME 8
-#define TAG_CHANNEL_NAME 9
-#define TAG_ADV_COUNT 10
-#define TAG_APP_SPECIFIC 0x80
+#define TAG_MAX_CARGO_PLUS_HEADER_READ  3
+#define TAG_MAX_TRANSFER_WRITE          4
+#define TAG_MAX_TRANSFER_READ           5
+#define TAG_NORMAL_CHANNEL              6
+#define TAG_WAKE_CHANNEL                7
+#define TAG_APP_NAME                    8
+#define TAG_CHANNEL_NAME                9
+#define TAG_ADV_COUNT                   10
+#define TAG_APP_SPECIFIC                0x80
 
-typedef void shtp_Callback_t(void * cookie, uint8_t *payload, uint16_t len, uint32_t timestamp);
-typedef void shtp_AdvertCallback_t(void * cookie, uint8_t tag, uint8_t len, uint8_t *value);
+typedef void
+shtp_Callback_t(void *cookie, const uint8_t *payload, uint16_t len, uint32_t timestamp);
+typedef void shtp_AdvertCallback_t(void *cookie, uint8_t tag, uint8_t len, const uint8_t *value);
 typedef void shtp_SendCallback_t(void *cookie);
 
 int shtp_init(void);
 
 void shtp_start(bool dfu);
-    
-int shtp_listenChan(const char * app, const char * chan,
-                    shtp_Callback_t *callback, void * cookie);
 
-int shtp_listenAdvert(const char * appName,
-                      shtp_AdvertCallback_t *advertCallback, void * cookie);
+int shtp_listenChan(const char *app, const char *chan, shtp_Callback_t *callback, void *cookie);
+
+int shtp_listenAdvert(const char *appName, shtp_AdvertCallback_t *advertCallback, void * cookie);
 
 uint8_t shtp_chanNo(const char * appName, const char * chanName);
 


### PR DESCRIPTION
This saves about 600 bytes, I'm sure more can be done too to reduce app/channel counts, will need to run to verify this though